### PR TITLE
Correctly identifying active/inactive compounds

### DIFF
--- a/Random Matrix Theory.ipynb
+++ b/Random Matrix Theory.ipynb
@@ -608,7 +608,7 @@
     "\n",
     "# Making \n",
     "binding_threshold = 1000  # units of nM\n",
-    "affinity_train_test = affinity_train_test.apply(lambda x: 0 if x<1000 else 1)\n",
+    "affinity_train_test = affinity_train_test.apply(lambda x: 0 if x > binding_threshold else 1)\n",
     "\n",
     "smiles_decoy = df_decoy['Canonical Smiles']\n",
     "smiles_decoy = smiles_decoy.reset_index()['Canonical Smiles']\n",


### PR DESCRIPTION
Variable `binding_threshold` created, but not used.

Also, the code identifies actives as inactives and vice-versa. Since the activity value used is IC50 or Ki, a smaller value indicates a more active compound. 

If, instead, pChEMBL Values were used to define activity, then compounds with a pChEMBL Value greater than some threshold would be identified as actives.